### PR TITLE
add renew chip functionality

### DIFF
--- a/odmpy/libby.py
+++ b/odmpy/libby.py
@@ -104,6 +104,8 @@ USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/605.1.15 (KHTML, like Gecko) "
     "Version/14.0.2 Safari/605.1.15"
 )
+DEWEY_CLIENT_VERSION = "18.5.2"
+
 EBOOK_DOWNLOADABLE_FORMATS = (
     LibbyFormats.EBookEPubAdobe,
     LibbyFormats.EBookEPubOpen,
@@ -427,6 +429,28 @@ class LibbyClient(object):
             # persist to settings
             self.save_settings(res)
         return res
+
+    def renew_chip(self, auto_save: bool = True, authenticated: bool = True) -> Dict:
+        """
+        Refresh the identity chip (contains auth token). This prevents having to clone with code every week
+        after original token expires.
+
+        :param auto_save:
+        :param authenticated:
+        :return:
+        """
+        res: Dict = self.make_request(
+            "chip",
+            params={"c":f"d:{DEWEY_CLIENT_VERSION}", "s":0, "v":self.identity.get("chip").split("-")[0] },
+            method="POST",
+            authenticated=authenticated,
+        )
+        if auto_save:
+            # persist to settings
+            self.save_settings(res)
+        return res
+
+
 
     def get_token(self) -> Optional[str]:
         return self.identity_token or self.identity.get("identity")

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -616,6 +616,12 @@ def run(custom_args: Optional[List[str]] = None, be_quiet: bool = False) -> None
         help="Remove previously saved odmpy Libby settings.",
     )
     parser_libby.add_argument(
+        "--renew",
+        dest="renew_chip",
+        action="store_true",
+        help="Renew identity token for Libby.",
+    )
+    parser_libby.add_argument(
         "--check",
         dest=OdmpyNoninteractiveOptions.Check,
         action="store_true",
@@ -782,6 +788,11 @@ def run(custom_args: Optional[List[str]] = None, be_quiet: bool = False) -> None
                 libby_client.clear_settings()
                 logger.info("Cleared settings.")
                 return
+            
+            if args.command_name == OdmpyCommands.Libby and args.renew_chip:
+                libby_client.renew_chip()
+                logger.info("Renewed identity.")
+                return
 
             if args.command_name == OdmpyCommands.Libby and args.check_signed_in:
                 if not libby_client.get_token():
@@ -838,7 +849,7 @@ def run(custom_args: Optional[List[str]] = None, be_quiet: bool = False) -> None
                         "Could not log in with code.\n"
                         "Make sure that you have entered the right code and within the time limit."
                     ) from ce
-
+            libby_client.renew_chip()
             synced_state = libby_client.sync()
             cards = synced_state.get("cards", [])
             # sort by checkout date so that recent most is at the bottom


### PR DESCRIPTION
function `renew_chip` is added to the `LibbyClient` class in `odmpy/libby.py` to refresh the identity chip, which contains the auth token. Saves a new identity (auth token) to the settings file when odmpy libby is run. This prevents the issue of the token expiring and needing to re-setup with a new code every week.